### PR TITLE
liveload host name use  window.location.hostname

### DIFF
--- a/build_defs/internal_do_not_use/j2cl_application.bzl
+++ b/build_defs/internal_do_not_use/j2cl_application.bzl
@@ -80,7 +80,7 @@ def j2cl_application(
     }
     _define_js("%s_dev_config" % name, define_dev_defaults, closure_defines)
 
-    index_html = "<script src='http://localhost:35729/livereload.js'></script>"
+    index_html = "<script language=\"JavaScript\">document.write(\"<script src=http://\" + window.location.hostname + \":35729/livereload.js></sc\" +\"ript>\")</script>"
     index_html += "<script src='%s_dev_config.js'></script>" % name
     index_html += "<script src='%s_dev.js'></script>" % name
     dev_resources = [


### PR DESCRIPTION
1. quote. 
the string fragment is `echo` to a file,  so the ugly` \"`
2. js parse 

\":35729/livereload.js></sc\" +\"ript>\"  !== \":35729/livereload.js></script>\"
the later one, chrome will throw parse error.

did not think this is the best solution.  better to serve liveload.js in the same port to avoid the hack?